### PR TITLE
Add static asset combination functions with CSP

### DIFF
--- a/yesod-middleware-csp.cabal
+++ b/yesod-middleware-csp.cabal
@@ -21,14 +21,19 @@ Library
     , base64-bytestring
     , bytestring            >=0.9 && <0.11
     , classy-prelude        >=0.10.2
+    , conduit
     , containers
+    , directory
+    , filepath
     , http-client
     , network-uri
+    , template-haskell
     , text
     , time
     , uuid
     , yesod                 >= 1.6.0
     , yesod-core            >= 1.6.15
+    , yesod-static          >= 1.6     && <1.7
 
 Test-Suite spec
   Type:                 exitcode-stdio-1.0
@@ -45,12 +50,16 @@ Test-Suite spec
     , case-insensitive
     , classy-prelude        >=0.10.2
     , classy-prelude-yesod  >= 1.1
+    , conduit
     , containers
+    , directory
     , fast-logger
+    , filepath
     , hspec
     , http-types
     , monad-logger
     , network-uri
+    , template-haskell
     , text
     , uuid
     , wai-extra             >=3.0     && <3.1

--- a/yesod-middleware-csp.nix
+++ b/yesod-middleware-csp.nix
@@ -1,22 +1,24 @@
 { mkDerivation, base, base64-bytestring, bytestring
-, case-insensitive, classy-prelude, classy-prelude-yesod
-, containers, fast-logger, hspec, http-client, http-types
-, monad-logger, network-uri, stdenv, text, time, uuid, wai-extra
-, yesod, yesod-core, yesod-static, yesod-test
+, case-insensitive, classy-prelude, classy-prelude-yesod, conduit
+, containers, directory, fast-logger, filepath, hspec, http-client
+, http-types, monad-logger, network-uri, stdenv, template-haskell
+, text, time, uuid, wai-extra, yesod, yesod-core, yesod-static
+, yesod-test
 }:
 mkDerivation {
   pname = "yesod-middleware-csp";
   version = "0.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    base base64-bytestring bytestring classy-prelude containers
-    http-client network-uri text time uuid yesod yesod-core
+    base base64-bytestring bytestring classy-prelude conduit containers
+    directory filepath http-client network-uri template-haskell text
+    time uuid yesod yesod-core yesod-static
   ];
   testHaskellDepends = [
     base base64-bytestring bytestring case-insensitive classy-prelude
-    classy-prelude-yesod containers fast-logger hspec http-types
-    monad-logger network-uri text uuid wai-extra yesod yesod-core
-    yesod-static yesod-test
+    classy-prelude-yesod conduit containers directory fast-logger
+    filepath hspec http-types monad-logger network-uri template-haskell
+    text uuid wai-extra yesod yesod-core yesod-static yesod-test
   ];
   description = "A middleware for building CSP headers on the fly";
   license = stdenv.lib.licenses.mit;


### PR DESCRIPTION
These are the same combining functions lifted from yesod-static, but with our own `addScript` and `addStylesheet` functions which include the CSP nonce.