### PR TITLE
Drop classy-prelude dependency

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -11,6 +11,5 @@
 :set -Wredundant-constraints
 :set -Wcpp-undef
 :set -Werror=incomplete-patterns
-:set -XNoImplicitPrelude
 :def! test (\expr -> return $ ":!clear\n:l test/Spec.hs\n:main " ++ expr ++"\n")
 :def! hlint const . return $ ":! hlint ./src ./test"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist
+dist-newstyle/
 cabal-dev
 *.o
 *.hi

--- a/src/Yesod/Middleware/CSP.hs
+++ b/src/Yesod/Middleware/CSP.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -26,13 +25,17 @@ module Yesod.Middleware.CSP
   , getRequestNonce
   ) where
 
-import ClassyPrelude
 import Conduit hiding (Source)
+import Control.Monad (when)
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.ByteString.Lazy as L
 import qualified Data.Map.Strict as M
+import Data.Maybe (fromMaybe)
 import qualified Data.Set as S
+import Data.String (IsString(..))
+import Data.Text (Text, pack, unpack)
 import qualified Data.Text as T
+import Data.Text.Encoding (decodeUtf8)
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TLE
 import Data.UUID (toASCIIBytes)
@@ -40,14 +43,14 @@ import Data.UUID.V4 (nextRandom)
 import Language.Haskell.TH
 import Language.Haskell.TH.Syntax as TH
 import System.Directory
-import System.FilePath (takeDirectory)
+import System.FilePath (takeDirectory, (</>), (<.>))
 import qualified System.FilePath as F
-import Yesod.Core(HandlerSite, MonadWidget, MonadHandler, HandlerFor)
+import Yesod.Core (HandlerSite, MonadWidget, MonadHandler, HandlerFor)
 import qualified Yesod.Core as Core
 import Yesod.Static hiding
        (CombineSettings, combineScripts', combineStylesheets')
 
-type DirSet = Map Directive (Set Source)
+type DirSet = M.Map Directive (S.Set Source)
 
 newtype CSPNonce = CSPNonce { unCSPNonce :: Text } deriving (Eq, Ord)
 
@@ -124,19 +127,19 @@ addCSP :: MonadWidget m => Directive -> Source -> m ()
 addCSP d s = cachedDirectives
   >>= Core.cacheSet . M.insertWith insertSource d (S.singleton s)
 
-insertSource :: Set Source -> Set Source -> Set Source
+insertSource :: S.Set Source -> S.Set Source -> S.Set Source
 insertSource a b = case S.toList a of
   [ None ]     -> a
   _            -> a <> S.filter (`notElem` [None]) b
 
-showSources :: Set Source -> Text
+showSources :: S.Set Source -> Text
 showSources = pack . unwords . map show . S.toList
 
-showDirective :: (Directive, Set Source) -> Text
-showDirective (d, s) = tshow d <> " " <> showSources s
+showDirective :: (Directive, S.Set Source) -> Text
+showDirective (d, s) = pack (show d) <> " " <> showSources s
 
 showDirectives :: DirSet -> Text
-showDirectives = intercalate "; " . map showDirective . M.toList
+showDirectives = T.intercalate "; " . map showDirective . M.toList
 
 cspHeaderName :: Text
 cspHeaderName = "Content-Security-Policy"
@@ -145,7 +148,7 @@ augment :: Maybe CSPNonce -> DirSet -> DirSet
 augment Nothing d = d
 augment (Just (CSPNonce n)) d =
   let srcs = S.fromList [ Nonce n ]
-      existingScriptSrcs = S.toList (fromMaybe S.empty (lookup ScriptSrc d))
+      existingScriptSrcs = S.toList (fromMaybe S.empty (M.lookup ScriptSrc d))
    in if any (`elem` existingScriptSrcs) [ None ]
       then d
       else M.insertWith insertSource ScriptSrc srcs d
@@ -154,8 +157,9 @@ addCSPMiddleware :: (HandlerFor m) a -> (HandlerFor m) a
 addCSPMiddleware handler = do
   (r, n) <- (,) <$> handler <*> Core.cacheGet
   d <- augment n <$> cachedDirectives
-  when (not (null (showDirectives d))) $
-    Core.addHeader cspHeaderName (showDirectives d)
+  let header = showDirectives d
+  when (not (T.null header)) $
+    Core.addHeader cspHeaderName header
   pure r
 
 -- | Get a nonce for the request

--- a/test/ExampleApp.hs
+++ b/test/ExampleApp.hs
@@ -9,7 +9,8 @@
 
 module ExampleApp where
 
-import ClassyPrelude.Yesod hiding (addScript, addScriptRemote)
+import Data.Text (Text)
+import Yesod hiding (addScript, addScriptRemote)
 import Yesod.Core.Types (Logger)
 import Yesod.EmbeddedStatic
 import Yesod.Middleware.CSP
@@ -39,19 +40,19 @@ getExample1 = defaultLayout $ do
   addCSP ScriptSrc Https
   addCSP ScriptSrc StrictDynamic
   addCSP ObjectSrc None
-  toWidget $ asText ""
+  toWidget ("" :: Text)
 
 getExample2 :: Handler Html
 getExample2 = defaultLayout $ do
   addCSP ScriptSrc None
   addCSP ScriptSrc Wildcard
-  toWidget $ asText ""
+  toWidget ("" :: Text)
 
 getExample3 :: Handler Html
 getExample3 = defaultLayout $ do
   addCSP ScriptSrc Wildcard
   addCSP ScriptSrc None
-  toWidget $ asText ""
+  toWidget ("" :: Text)
 
 getExample4 :: Handler Html
 getExample4 = defaultLayout $ do
@@ -59,26 +60,26 @@ getExample4 = defaultLayout $ do
   addCSP ScriptSrc None
   addCSP ScriptSrc DataScheme
   addCSP ScriptSrc Https
-  toWidget $ asText ""
+  toWidget ("" :: Text)
 
 getExample5 :: Handler Html
 getExample5 = defaultLayout $ do
   addScript $ StaticR js_test_js
-  toWidget $ asText ""
+  toWidget ("" :: Text)
 
 getExample6 :: Handler Html
 getExample6 = defaultLayout $ do
   addScriptRemote "https://example.com/test.js"
-  toWidget $ asText ""
+  toWidget ("" :: Text)
 
 getExample7 :: Handler Html
-getExample7 = defaultLayout $ toWidget $ asText ""
+getExample7 = defaultLayout $ toWidget ("" :: Text)
 
 getExample8 :: Handler Html
 getExample8 = defaultLayout $ do
   addScript $ StaticR js_test_js
   addCSP ScriptSrc None
-  toWidget $ asText ""
+  toWidget ("" :: Text)
 
 instance Yesod ExampleApp where
   yesodMiddleware = addCSPMiddleware

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -6,12 +6,16 @@ module TestImport
   , module X
   ) where
 
+import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as M
+import Data.Maybe (listToMaybe)
+import Data.Text (Text)
+import Data.Text.Encoding (encodeUtf8, decodeUtf8)
+import qualified Data.Text as T
 import qualified System.Log.FastLogger as F
 import qualified Yesod
 import qualified Yesod.Default.Config2 as C
 
-import ClassyPrelude as X hiding (Handler, delete, deleteBy)
 import Data.CaseInsensitive (CI)
 import ExampleApp as X
 import Network.Wai.Test (SResponse(..))
@@ -24,22 +28,27 @@ withApp = before $ do
   logF <- F.newStdoutLoggerSet 1 >>= C.makeYesodLogger
   pure (ExampleApp logF eStatic, Yesod.defaultMiddlewaresNoLogging)
 
-assertCSP :: HasCallStack => ByteString -> YesodExample site ()
+assertCSP :: HasCallStack => BS.ByteString -> YesodExample site ()
 assertCSP = assertHeader "Content-Security-Policy"
 
-lookupResponseHeader :: CI ByteString -> YesodExample site (Maybe ByteString)
+lookupResponseHeader :: CI BS.ByteString -> YesodExample site (Maybe BS.ByteString)
 lookupResponseHeader k = (lookupHeader =<<) <$> getResponse
-  where lookupHeader = lookup k . M.fromList . simpleHeaders
+  where lookupHeader = M.lookup k . M.fromList . simpleHeaders
 
-getNonceFromCSP :: YesodExample site (Maybe ByteString)
+getNonceFromCSP :: YesodExample site (Maybe BS.ByteString)
 getNonceFromCSP = lookupResponseHeader "Content-Security-Policy"
-  >>= \h -> pure $ filter (isPrefixOf "'nonce-") . words . decodeUtf8 <$> h
-    >>= fmap (encodeUtf8 . dropEnd 1 . dropPrefix "'nonce-") . headMay
+  >>= \h -> pure $ filter (T.isPrefixOf "'nonce-") . T.words . decodeUtf8 <$> h
+    >>= fmap (encodeUtf8 . T.dropEnd 1 . dropPrefix "'nonce-") . listToMaybe
+
+dropPrefix :: Text -> Text -> Text
+dropPrefix prefix t = case T.stripPrefix prefix t of
+  Just rest -> rest
+  Nothing   -> t
 
 getAttrFromResponseMatch :: Query -> Text -> YesodExample site (Maybe Text)
 getAttrFromResponseMatch q a = do
   body <- getAttr . simpleBody <<$>> getResponse
-  pure $ body >>= either (const Nothing) headMay >>= headMay
+  pure $ body >>= either (const Nothing) listToMaybe >>= listToMaybe
   where getAttr b = findAttributeBySelector b q a
 
 infixl 4 <<$>>

--- a/test/Yesod/Middleware/CSPSpec.hs
+++ b/test/Yesod/Middleware/CSPSpec.hs
@@ -3,6 +3,7 @@
 module Yesod.Middleware.CSPSpec (spec) where
 
 import Data.Maybe (fromJust)
+import Data.Text.Encoding (encodeUtf8)
 import TestImport
 
 spec :: Spec

--- a/yesod-middleware-csp.cabal
+++ b/yesod-middleware-csp.cabal
@@ -24,17 +24,15 @@ library
   default-language:   Haskell2010
   hs-source-dirs:     src
   ghc-options:        -Wall
-  default-extensions: NoImplicitPrelude
   exposed-modules:    Yesod.Middleware.CSP
   build-depends:
       base               >=4      && <5
     , base64-bytestring  >=1.0.0  && <1.3
-    , bytestring         >=0.9    && <0.12
-    , classy-prelude     >=1.5.0  && <1.6
+    , bytestring         >=0.9    && <0.13
     , conduit            >=1.3.1  && <1.4
-    , containers         >=0.6.0  && <0.7
+    , containers         >=0.6.0  && <0.8
     , directory          >=1.3.3  && <1.4
-    , filepath           >=1.4.2  && <1.5
+    , filepath           >=1.4.2  && <1.6
     , http-client        >=0.6.4  && <0.8
     , network-uri        >=2.6.1  && <2.7
     , template-haskell   >=2.14.0 && <3.0
@@ -50,15 +48,12 @@ test-suite spec
   default-language:   Haskell2010
   hs-source-dirs:     src test
   ghc-options:        -Wall
-  default-extensions: NoImplicitPrelude
   main-is:            Spec.hs
   build-depends:
       base
     , base64-bytestring
-    , bytestring            >=0.9    
+    , bytestring
     , case-insensitive
-    , classy-prelude        >=0.10.2
-    , classy-prelude-yesod  >=1.1
     , conduit
     , containers
     , directory
@@ -66,15 +61,14 @@ test-suite spec
     , filepath
     , hspec
     , http-types
-    , monad-logger
     , network-uri
     , template-haskell
     , text
     , uuid
     , wai-extra             >=3.0
     , yesod
-    , yesod-core            >=1.6.15 
-    , yesod-static          >=1.6    
+    , yesod-core            >=1.6.15
+    , yesod-static          >=1.6
     , yesod-test
 
   other-modules:


### PR DESCRIPTION
## Summary

- Replace `classy-prelude` and `classy-prelude-yesod` with standard Prelude + explicit imports from `base` and `text`. The problem is that classy-prelude is no longer maintained and has strict version constraints.
- Fix bug: `augment` used list-based `lookup` on a `Map`, now uses `M.lookup`
- Fix: `showDirectives` was computed twice in `addCSPMiddleware`, now computed once
- Loosen `bytestring`, `containers`, and `filepath` upper bounds to support newer GHCs
- Remove `NoImplicitPrelude` default extension from cabal file and `.ghci`