### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,42 +11,25 @@ a nonce to the tag, and the right headers to the request.
 
 Because there is no good way of enforcing CSP
 at typelevel in yesod,
-It's best to override classy prelude with your
-own custom prelude.
-This allows hiding the addScript functions from
-there with the ones provided by this library:
+it's best to hide the addScript functions from
+yesod with the ones provided by this library:
 
 ```haskell
-
--- | Mirrors classy prelude yesod but with our supercede patches
-module Supercede.Prelude.Yesod
-  ( -- * rexport
-    module X
-  -- ** use CSP variant instead of yesod's
-  , addScriptEither
-  , addScript
-  , addScriptRemote
-  ) where
-
-import Supercede.Prelude as X hiding (delete, deleteBy, Handler (..))
-import Yesod as X hiding (addScriptEither, addScript, addScriptRemote, addScriptAttrs, addScriptRemoteAttrs)
-
-import Yesod.Middleware.CSP (addScriptEither, addScript, addScriptRemote)
-
+import Yesod hiding (addScript, addScriptRemote)
+import Yesod.Middleware.CSP (addScript, addScriptRemote, addCSPMiddleware)
 ```
 
-Then in hlint you can simply dis-recommend usage of classy prelude:
+Then wire up the middleware in your `Yesod` instance:
 
 ```haskell
-- modules:
-  - {name: [ClassyPrelude], message: "Use Supercede.Prelude instead"}
-  - {name: [ClassyPrelude.Yesod], message: "Use Supercede.Prelude.Yesod instead"}
+instance Yesod App where
+  yesodMiddleware = addCSPMiddleware
 ```
 
 ## How to run tests
 
 ```
-cabal configure --enable-tests && cabal build && cabal test
+nix build
 ```
 
 ## Contributing

--- a/changelog.md
+++ b/changelog.md
@@ -2,17 +2,23 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 1.3.0 - 2026-04-28
+
++ Drop dependency on classy-prelude; use standard Prelude and explicit imports
++ Loosen dependency bounds to support GHC 9.6 through 9.10
++ Switch build tooling from Stack to Nix flakes
++ Fix test suite to depend on the library instead of recompiling sources
++ Bump cabal-version to 2.4
+
 ## 1.2.0 - 2023-06-14
 
 + bump bounds
-+ add upperboudns from cabal-gen-bounds
++ add upperbounds from cabal-gen-bounds
 + add stackage ci
 
 ## 1.1.0 - 2022-07-15
 
 + Add new directive ManifestSrc
-
-## Unreleased
 
 ## 1.0.2 - 2022-07-12
 

--- a/yesod-middleware-csp.cabal
+++ b/yesod-middleware-csp.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               yesod-middleware-csp
-version:            1.2.0
+version:            1.3.0
 author:             Jezen Thomas <jezen@supercede.com>
 maintainer:         Jezen Thomas <jezen@supercede.com>
 license:            MIT


### PR DESCRIPTION
## Summary

- Bump version to 1.3.0
- Update changelog with all changes since 1.2.0
- Replace classy-prelude-specific README example with a generic one